### PR TITLE
README: Use the default name for the repository (`ToyFHE.jl`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ versions, first clone this package to a location of your
 choice:
 
 ```
-$ git clone https://github.com/JuliaComputing/ToyFHE.jl ToyFHE
+$ git clone https://github.com/JuliaComputing/ToyFHE.jl ToyFHE.jl
 ```
 
 Then load up the project within Julia:
 ```
-$ julia --project=ToyFHE
+$ julia --project=ToyFHE.jl
 ```
 
 If you do not have the correct versions of the dependencies installed, you may be asked to install them via `instantiate`:
@@ -34,7 +34,7 @@ julia> Pkg.instantiate()
 ## Examples
 
 ```julia
-julia> cd("ToyFHE/examples/encrypted_mnist")
+julia> cd("ToyFHE.jl/examples/encrypted_mnist")
 
 julia> include("train.jl")
 


### PR DESCRIPTION
The default name for the directory that Git will create when cloning this repository is `ToyFHE.jl/`.

I think it's a little confusing that the README recommends cloning this repo into a directory called `ToyFHE/`. I think it's easiest to go with the default `ToyFHE.jl/`.

This PR makes three small changes to the README to that effect.